### PR TITLE
attach .ReadStream to fs, like node fs

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,4 +3,7 @@ var levelup = require('levelup');
 var fs = require('level-filesystem');
 
 var db = levelup('level-filesystem', {db:leveljs});
-module.exports = fs(db);
+var fsdb = fs(db);
+fsdb.ReadStream = require("readable-stream/readable")
+
+module.exports = fsdb


### PR DESCRIPTION
node's fs module has the readable stream constructor attached to the main library. Some node modules that use fs reference this constructor, which throws an Error when using browserify-fs. This seems to solve the problem. 

Great library btw :)