### PR TITLE
Update dependency "levelup" version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   "dependencies": {
     "level-filesystem": "^1.0.1",
     "level-js": "^2.1.3",
-    "levelup": "^0.18.2"
+    "levelup": "^2.0.1"
   }
 }


### PR DESCRIPTION
I got a GitHub warning:

![screen shot 2017-12-07 at 11 37 30 am](https://user-images.githubusercontent.com/10948652/33735595-97006bd0-db44-11e7-9787-0b44200bf784.png)

Then when I trace my npm dependency tree,
![screen shot 2017-12-07 at 11 47 40 am](https://user-images.githubusercontent.com/10948652/33735599-98a9ae4c-db44-11e7-9703-cc3e44261174.png)

I find out that `browserify-fs` is using an outdated version of `levelup` that uses a dependency called `semver` that has potential vulnerability.

This PR is proposing to update the version of `levelup` to `2.0.1`.